### PR TITLE
Add os_support stanzas to selected barclamps. [5/12]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,6 +23,8 @@ barclamp:
     - nova
   member:
     - openstack
+  os_support:
+    - ubuntu-12.04
 
 smoketest:
   timeout: 2400


### PR DESCRIPTION
This pull request adds os_support stanzas to various barclamps to
allow the dev tool to infer the proper OS for a given build.

 crowbar.yml |    2 ++
 1 file changed, 2 insertions(+)

Crowbar-Pull-ID: 18a9548803fe8236bd2918dcca092fdf4ffa73be

Crowbar-Release: development
