### PR TITLE
Move Docs and BDD to top level of barclamp [6/20]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -30,7 +30,7 @@ smoketest:
   timeout: 2400
 
 crowbar:
-  layout: 2
+  layout: 1.9
   order: 99
   run_order: 99
   chef_order: 99

--- a/doc/barclamps/wrong_name.md
+++ b/doc/barclamps/wrong_name.md
@@ -1,0 +1,3 @@
+## NOT UPDATED >>> Barclamp Info
+
+This file should have general information about the barclamp

--- a/doc/licenses/wrong_name.md
+++ b/doc/licenses/wrong_name.md
@@ -1,0 +1,14 @@
+## NOT UPDATED >>> Licenses
+
+THIS BARCLAMP is made available by Dell under the Apache 2 license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at    
+    http://www.apache.org/licenses/LICENSE-2.0    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+

--- a/doc/tempest.yml
+++ b/doc/tempest.yml
@@ -1,0 +1,4 @@
+# theses are the default meta_data values
+license:    Apache 2
+copyright:  2013 by Dell, Inc
+date:       January 16, 2013


### PR DESCRIPTION
This pull reflects a movement to make things easier to find and more logical.

The docs have moved from under the crowbar_framework to barclamp/doc
The BDD have made a similar move.

There are still clean-ups to get the doc system totally working, but the 
basic files are all in the right place AND the install still works.

Next step will be to get the doc code working again.

BDD will also be fixed in the dev run-unit-tests

 crowbar.yml                 |    2 +-
 doc/barclamps/wrong_name.md |    3 +++
 doc/licenses/wrong_name.md  |   14 ++++++++++++++
 doc/tempest.yml             |    4 ++++
 4 files changed, 22 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 8fd3f586f8e29b7bf0af886ccc15be0e9c3290e1

Crowbar-Release: development
