### PR TITLE
Make Tempest much more amenable to being run without using PFS. [2/2]

### DIFF
--- a/chef/cookbooks/tempest/recipes/install.rb
+++ b/chef/cookbooks/tempest/recipes/install.rb
@@ -18,9 +18,15 @@
 # limitations under the License.
 #
 
-package "python-httplib2"
-package "python-nose"
-package "python-unittest2"
+# From the pip-requires -- all the Ubuntu packages for tempest prereqs
+packages = %w(python-anyjson python-nose python-httplib2 python-testtools python-lxml
+   python-boto python-paramiko python-netaddr python-glanceclient
+   python-keystoneclient python-novaclient python-quantumclient
+   python-testresources python-keyring python-testrepository python-oslo.config)
+
+packages.each do |p|
+  package p
+end
 
 begin
   provisioner = search(:node, "roles:provisioner-server").first
@@ -87,11 +93,12 @@ if node[:tempest][:use_virtualenv]
   nosetests = "/opt/tempest/.venv/bin/python #{nosetests}"
 end
 
-execute "pip_install_reqs_for_tempest" do
-  cwd "/opt/tempest/"
-  command "#{pip_cmd} -r tools/pip-requires"
+if node[:tempest][:use_pfs]
+  execute "pip_install_reqs_for_tempest" do
+    cwd "/opt/tempest/"
+    command "#{pip_cmd} -r tools/pip-requires"
+  end
 end
-
 
 if nova[:nova][:use_gitrepo]!=true
   package "python-novaclient"

--- a/chef/data_bags/crowbar/bc-template-tempest.json
+++ b/chef/data_bags/crowbar/bc-template-tempest.json
@@ -11,6 +11,7 @@
       "tempest_user_username": "tempest",
       "tempest_user_tenant": "tempest",
       "use_virtualenv": true,
+      "use_pfs": true,
       "nova_instance": "none",
       "tempest_path": "/opt/tempest"
     }

--- a/chef/data_bags/crowbar/bc-template-tempest.schema
+++ b/chef/data_bags/crowbar/bc-template-tempest.schema
@@ -21,6 +21,7 @@
             "tempest_user_tenant": { "type": "str", "required": true },
             "tempest_test_image": { "type": "str", "required": true },
             "use_virtualenv": { "type": "bool", "required": true },
+            "use_pfs": { "type": "bool", "required": true },
             "tempest_path" : {"type": "str", "required": true }
           }
         }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -20,6 +20,10 @@ barclamp:
   display: Tempest
   version: 0
   requires:
+    # We need git for now because we only work in PFS mode.
+    # This will change once Ubuntu starts packaging the
+    # right version of python-testtools
+    - git
     - nova
   member:
     - openstack
@@ -100,16 +104,23 @@ debs:
     repos:
       - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-updates/grizzly main
       - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-proposed/grizzly main
-
-  pkgs:
-    - python-unittest2
-    - python-nose
-    - python-httplib2
-    - python-glanceclient
-    - python-novaclient
-    - python-testresources
-    - python-testtools
-
+    pkgs:
+      - python-anyjson
+      - python-nose
+      - python-httplib2
+      - python-testtools
+      - python-lxml
+      - python-boto
+      - python-paramiko
+      - python-netaddr
+      - python-glanceclient
+      - python-keystoneclient
+      - python-novaclient
+      - python-quantumclient
+      - python-testresources
+      - python-keyring
+      - python-testrepository
+      - python-oslo.config
 pips:
   - anyjson
   - nose


### PR DESCRIPTION
Allow Tempest to work with OS native packages, once Ubuntu gets all
the packages it needs up to the proper revisions.

In the mean time, default to using PFS for Tempest.

 chef/cookbooks/tempest/recipes/install.rb         |   21 +++++++++-----
 chef/data_bags/crowbar/bc-template-tempest.json   |    1 +
 chef/data_bags/crowbar/bc-template-tempest.schema |    1 +
 crowbar.yml                                       |   31 ++++++++++++++-------
 4 files changed, 37 insertions(+), 17 deletions(-)

Crowbar-Pull-ID: 8f21319d8693626bd2e77f301f9477dda04f0118

Crowbar-Release: pebbles
