### PR TITLE
[NavMenu] Don't open in new tab/window

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -41,7 +41,7 @@ crowbar:
 
 nav:
   utils:
-    tempest: '"/tempest/dashboard/", { :link => { :target => "_blank" } }'
+    tempest: '"/tempest/dashboard/"'
 
 locale_additions:
   en:


### PR DESCRIPTION
All other barclamps open in the same tab/window, so we should be
consistent here. General rule is that if it's in the same domain, don't
open a new tab/window.

As requested in
https://github.com/crowbar/barclamp-swift/pull/99#issuecomment-20192359
