### PR TITLE
Added some scripting around the use_pfs and use_virtualenv fields to toggle visibility of use_virtualenv based on value of use_pfs.  Also changed option labels to true/false instead of yes/no to be consistant with rest of barclamps. [1/1]

### DIFF
--- a/crowbar_framework/app/views/barclamp/tempest/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/tempest/_edit_attributes.html.haml
@@ -7,10 +7,6 @@
     %p
       %label{ :for => :nova_instance }= t('.nova_instance')
       = instance_selector("nova", :nova_instance, "nova_instance", @proposal)
-    -#
-      %p
-        %label{ :for => :use_virtualenv }= t('.use_virtualenv')
-        = select_tag :use_virtualenv, options_for_select([['yes','true'], ['no', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["use_virtualenv"].to_s), :onchange => "update_value('use_virtualenv', 'use_virtualenv', 'boolean')"
     %p
       %label{:for => "tempest_user"}= t('.tempest_user')
     %p
@@ -27,4 +23,31 @@
       %input#tempest_adm_password{:type => "password", :name => "tempest_adm_password", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["tempest_adm_password"], :onchange => "update_value('tempest_adm_password','tempest_adm_password', 'string')"}
     %p
       %label{ :for => :use_pfs }= t('.use_pfs')
-      = select_tag :use_pfs, options_for_select([['yes','true'], ['no', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["use_pfs"].to_s), :onchange => "update_value('use_pfs', 'use_pfs', 'boolean')"
+      = select_tag :use_pfs, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["use_pfs"].to_s)
+    %p#use_virtenv_p
+      %label{ :for => :use_virtualenv }= t('.use_virtualenv')
+      = select_tag :use_virtualenv, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["use_virtualenv"].to_s)
+
+:javascript
+$(document).ready(function(){
+  var use_pfs_val = $("#use_pfs").val() === "true"
+  if (use_pfs_val){
+    $("#use_virtenv_p").show();
+  } else {
+    $("#use_virtenv_p").hide();
+  }
+ 
+  $("#use_pfs").change(function (){
+    var val = $(this).val() === "true";
+    if(val){
+      $("#use_virtenv_p").show();
+      $("#use_virtualenv").change(function (){
+         update_value('use_virtualenv', 'use_virtualenv', 'boolean');
+      });
+    } else {
+      $("#use_virtualenv").val('false');
+      $("#use_virtenv_p").hide();
+    }
+    update_value('use_pfs', 'use_pfs', 'boolean');
+  });
+});


### PR DESCRIPTION
 .../barclamp/tempest/_edit_attributes.html.haml    |   33 +++++++++++++++++---
 1 file changed, 28 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: 85dc77871d1c538d3392169ca5d115d9705b1b34

Crowbar-Release: mesa-1.6
