### PR TITLE
Use timestamp for building row ids for avoid duplicates which breaks expand/collapse scripting [1/1]

### DIFF
--- a/crowbar_framework/app/views/barclamp/tempest/_results.html.haml
+++ b/crowbar_framework/app/views/barclamp/tempest/_results.html.haml
@@ -14,7 +14,7 @@
           - status = test.has_elements? ? test.elements[1].name : 'passed'
           - test_name = test.attribute('name').to_s()
           - test_time = test.attribute('time').to_s()
-          - test_id = '%02x' % (class_name + test_name + test_time).hash
+          - test_id = ('%02x' % (class_name + test_name + Time.now.to_f.to_s).hash)
           %tr{:class => "test _#{status}", :id => test_id}
             %td.misc
               - if test.has_elements? 


### PR DESCRIPTION
 .../app/views/barclamp/tempest/_results.html.haml  |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 7a408552d8008051a1548e6368064da42a1b7e14

Crowbar-Release: mesa-1.6.1
