### PR TITLE
Havana repo updates to crowbar.yml files for the openstack barclamps [2/9]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -168,4 +168,4 @@ pips:
 
 extra_files:
   - http://launchpad.net/cirros/trunk/0.3.0/+download/cirros-0.3.0-x86_64-uec.tar.gz tempest
-  - https://github.com/openstack/tempest/tarball/stable/havana.tar.gz tempest
+  # - https://github.com/openstack/tempest/tarball/stable/grizzly.tar.gz tempest


### PR DESCRIPTION
Updated the crowbar.yml files for the openstack barclamps so that the crowbar-bar-cache could be updated with the latest havana packages

 crowbar.yml |    6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 3bb4c6cc22881de90084cba6ee8a6f1664dffb8c

Crowbar-Release: roxy
