### PR TITLE
Replaced barclamp controller initialzer with before filter

### DIFF
--- a/crowbar_framework/app/controllers/tempest_controller.rb
+++ b/crowbar_framework/app/controllers/tempest_controller.rb
@@ -16,10 +16,6 @@
 require "rexml/document"
 
 class TempestController < BarclampController
-  def initialize
-    @service_object = TempestService.new logger
-  end
-
   def raise_not_found
     raise ActionController::RoutingError.new('Not Found')
   end
@@ -89,5 +85,11 @@ class TempestController < BarclampController
         render :template => "barclamp/#{@bc_name}/results.html.haml"
       }
     end
+  end
+
+  protected
+
+  def initialize_service
+    @service_object = TempestService.new logger
   end
 end


### PR DESCRIPTION
I transfered the service initialize into a before filter. It's a quite dirty practice to overwrite the controller initializer and the way it is done now will result in problems while upgrading to rails 3 or 4.
**This depends on https://github.com/crowbar/barclamp-crowbar/pull/1036**
