### PR TITLE
Renamed updated gitignore correclty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-scripts/
+.DS_Store
+*~
+
+.coverage/
+rubydeps.*

--- a/gitignore
+++ b/gitignore
@@ -1,5 +1,0 @@
-.DS_Store
-*~
-
-.coverage/
-rubydeps.*


### PR DESCRIPTION
Within the commit
https://github.com/crowbar/barclamp-tempest/commit/7aba48be9889a6000bc7f3672a73011eb4b200c5
i have accidently renamed the gitignore file wrong. This commit will fix
the gitignore replacement.
