### PR TITLE
Only enable tempest for LBaaS if it got enabled

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -259,6 +259,16 @@ horizons = search(:node, "roles:nova_dashboard-server") || []
 
 neutrons = search(:node, "roles:neutron-server") || []
 
+# FIXME: this should be 'all' instead
+#
+neutron_api_extensions = "provider,security-group,dhcp_agent_scheduler,external-net,ext-gw-mode,binding,agent,quotas,l3_agent_scheduler,multi-provider,router,extra_dhcp_opt,allowed-address-pairs,extraroute,metering,fwaas,service-type"
+
+unless neutrons[0].nil?
+  if neutrons[0][:neutron][:use_lbaas] then
+    neutron_api_extensions += ",lbaas"
+  end
+end
+
 public_network_id = `neutron --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url http://#{keystone_address}:5000/v2.0 net-list -f csv -c id -- --name floating | tail -n 1 | cut -d'"' -f2 `
 
 template "#{tempest_conf}" do
@@ -290,6 +300,7 @@ template "#{tempest_conf}" do
     :use_ceilometer => !ceilometers.empty?,
     :use_horizon => !horizons.empty?,
     :use_neutron => !neutrons.empty?,
+    :neutron_api_extensions => neutron_api_extensions,
     :use_swift => !swifts.empty?
   )
 end

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -726,7 +726,7 @@ public_network_id=<%= @public_network_id %>
 # A list of enabled network extensions with a special entry
 # all which indicates every extension is enabled (list value)
 # FIXME: this should be "all"
-api_extensions=provider,security-group,dhcp_agent_scheduler,external-net,ext-gw-mode,binding,agent,quotas,l3_agent_scheduler,multi-provider,router,extra_dhcp_opt,allowed-address-pairs,extraroute,metering,fwaas,service-type
+api_extensions=<%= @neutron_api_extensions %>
 
 
 [object-storage]


### PR DESCRIPTION
Since it is disabled by default, this otherwise causes
unnecessary failures..
