### PR TITLE
Set http-accessible url for tempest http image test

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -289,6 +289,7 @@ template "#{tempest_conf}" do
     :flavor_ref => flavor_ref,
     :img_host => glance_address,
     :img_port => glance_port,
+    :http_image => node[:tempest][:tempest_test_image],
     :key_host => keystone_address,
     :key_port => keystone_port,
     :keystone_settings => keystone_settings,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -611,7 +611,7 @@ admin_password=<%= @keystone_settings['admin_password'] %>
 #endpoint_type=publicURL
 
 # http accessible image (string value)
-#http_image=http://download.cirros-cloud.net/0.3.1/cirros-0.3.1-x86_64-uec.tar.gz
+http_image=<%= @http_image %>
 
 
 [image-feature-enabled]


### PR DESCRIPTION
The default might not be accessible in the test environment,
and the admin node already provides it for free..
