### PR TITLE
Configure tempest for testing heat stacks

### DIFF
--- a/chef/cookbooks/tempest/attributes/default.rb
+++ b/chef/cookbooks/tempest/attributes/default.rb
@@ -1,2 +1,5 @@
 default[:tempest][:use_virtualenv] = false
 
+if node.platform == "suse"
+  default[:tempest][:heat_test_image_name] = "SLE11SP3-x86_64-cfntools"
+end

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -797,15 +797,15 @@ api_extensions=<%= @neutron_api_extensions %>
 
 # Timeout in seconds to wait for a stack to build. (integer
 # value)
-#build_timeout=1200
+build_timeout=600
 
 # Instance type for tests. Needs to be big enough for a full
 # OS plus the test workload (string value)
-instance_type=<%=@flavor_ref %>
+instance_type=<%=@heat_flavor_ref %>
 
 # Name of heat-cfntools enabled image to use when launching
 # test instances. (string value)
-image_ref=<%=img_id %>
+image_ref=<%= `cat #{@heat_machine_id_file}`.strip %>
 
 # Name of existing keypair to launch servers with. (string
 # value)


### PR DESCRIPTION
Our heat image requires more memory to boot properly, so
add a special heat flavor for the image. Also try to
autodiscover the image and add it to the tempest.conf
