### PR TITLE
Forcefully enable v3 api tests

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -368,18 +368,18 @@ password=<%= @keystone_settings['admin_password'] %>
 #
 
 # If false, skip all nova v3 tests. (boolean value)
-#api_v3=true
+api_v3=true
 
 # If false, skip disk config tests (boolean value)
 #disk_config=true
 
 # A list of enabled compute extensions with a special entry
 # all which indicates every extension is enabled (list value)
-#api_extensions=all
+api_extensions=all
 
 # A list of enabled v3 extensions with a special entry all
 # which indicates every extension is enabled (list value)
-#api_v3_extensions=all
+api_v3_extensions=all
 
 # Does the test environment support changing the admin
 # password? (boolean value)


### PR DESCRIPTION
They are disabled for icehouse by default, but since we
enable v3, we probably should test it as well.
