### PR TITLE
Use fixed network for ssh

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -797,7 +797,7 @@ api_extensions=<%= @neutron_api_extensions %>
 
 # Timeout in seconds to wait for a stack to build. (integer
 # value)
-build_timeout=600
+build_timeout=2000
 
 # Instance type for tests. Needs to be big enough for a full
 # OS plus the test workload (string value)


### PR DESCRIPTION
This is a bit of a red herring.. we actually want to use floating,
and we configure that as ssh_connect_method=floating, but it
seems it still needs to know the name of the fixed network then.
