### PR TITLE
Change order so that tempest appears and runs after all barclamps

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -35,9 +35,9 @@ smoketest:
 
 crowbar:
   layout: 1
-  order: 99
-  run_order: 99
-  chef_order: 99
+  order: 199
+  run_order: 199
+  chef_order: 199
   proposal_schema_version: 3
 
 nav:


### PR DESCRIPTION
It was still before the trove barclamp, and the chef recipes were run
too early too.
