### PR TITLE
Do not use tempest recipes when node is in readying

### DIFF
--- a/chef/data_bags/crowbar/bc-template-tempest.json
+++ b/chef/data_bags/crowbar/bc-template-tempest.json
@@ -26,7 +26,7 @@
       "crowbar-revision": 0,
       "crowbar-applied": false,
       "element_states": {
-        "tempest": [ "readying", "ready", "applying" ]
+        "tempest": [ "ready", "applying" ]
       },
       "elements": {},
       "element_order": [


### PR DESCRIPTION
Readying means that we're rebooting, and all services might not be
started yet. The way the tempest barclamp works is kind of unusual as it
requires very early on things to run, and on boot, that just fails.

Since tempest is not critical, skip that during crowbar_join. (And the
recipe just set up files, so it's no big deal anyway)

https://bugzilla.novell.com/show_bug.cgi?id=886783
