### PR TITLE
Correctly set cinder storage_protocol and vendor_name

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -307,9 +307,29 @@ public_network_id = `neutron --os_username #{tempest_comp_user} --os_password #{
 
 
 storage_protocol = "iSCSI"
+vendor_name = "Open Source"
 cinders[0][:cinder][:volumes].each do |volume|
   if volume[:backend_driver] == "rbd"
     storage_protocol = "ceph"
+    break
+  elsif volume[:backend_driver] == "emc"
+    vendor_name = "EMC"
+    break
+  elsif volume[:backend_driver] == "eqlx"
+    vendor_name = "Dell"
+    break
+  elsif volume[:backend_driver] == "eternus"
+    vendor_name = "FUJITSU"
+    storage_protocol = "fibre_channel" if volume[:eternus][:protocol] == "fc"
+    break
+  elsif volume[:backend_driver] == "netapp"
+    vendor_name = "NetApp"
+    storage_protocol = "nfs" if volume[:netapp][:storage_protocol] == "nfs"
+    break
+  elsif volume[:backend_driver] == "vmware"
+    vendor_name = "VMware"
+    storage_protocol = "LSI Logic SCSI"
+    break
   end
 end
 
@@ -358,6 +378,7 @@ template "#{tempest_conf}" do
     :use_neutron => !neutrons.empty?,
     :neutron_api_extensions => neutron_api_extensions,
     :storage_protocol => storage_protocol,
+    :vendor_name => vendor_name,
     :cinder_multi_backend => cinder_multi_backend,
     :cinder_backend1_name => cinder_backend1_name,
     :cinder_backend2_name => cinder_backend2_name,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -1027,7 +1027,7 @@ storage_protocol=<%= @storage_protocol %>
 
 # Backend vendor to target when creating volume types (string
 # value)
-#vendor_name=Open Source
+vendor_name=<%= @vendor_name %>
 
 # Disk format to use when copying a volume to image (string
 # value)


### PR DESCRIPTION
We take the first non-LVM backend and do the right thing.

Fix failures in
tempest.api.volume.admin.test_volume_types.VolumeTypesTest.test_create_get_delete_volume_with_volume_type_and_extra_specs
when only these backends are used.
