### PR TITLE
Add custom region support

### DIFF
--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -520,7 +520,7 @@ uri_v3=http://<%= @key_host %>:5000/v3
 # services' region name unless they are set explicitly. If no
 # such region is found in the service catalog, the first found
 # one is used. (string value)
-#region=RegionOne
+region=<%= @keystone_settings['endpoint_region'] %>
 
 # The endpoint type to use for the identity service. (string
 # value)

--- a/chef/cookbooks/tempest/templates/default/tempest_cleanup.sh.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest_cleanup.sh.erb
@@ -2,6 +2,7 @@
 
 export OS_AUTH_URL=http://<%= @key_host %>:<%= @key_port %>/v2.0/
 export OS_AUTH_STRATEGY=keystone
+export OS_REGION_NAME='<%= @keystone_settings['endpoint_region'] %>'
 
 username=<%= @comp_user %>
 password=<%= @comp_pass %>

--- a/chef/cookbooks/tempest/templates/default/tempest_smoketest.sh.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest_smoketest.sh.erb
@@ -2,6 +2,7 @@
 
 export OS_AUTH_URL=http://<%= @key_host %>:<%= @key_port %>/v2.0/
 export OS_AUTH_STRATEGY=keystone
+export OS_REGION_NAME='<%= @keystone_settings['endpoint_region'] %>'
 
 username=<%= @comp_user %>
 password=<%= @comp_pass %>


### PR DESCRIPTION
Use the region name set in the keystone barclamp.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
