### PR TITLE
Add back missing localization string

### DIFF
--- a/crowbar_framework/config/locales/tempest/en.yml
+++ b/crowbar_framework/config/locales/tempest/en.yml
@@ -69,3 +69,4 @@ en:
         tempest_adm_username: 'Choose Tempest admin username'
         tempest_adm_password: 'Choose Tempest admin password'
         tempest_user_tenant: 'Choose tenant'
+        nova_instance: 'Nova'


### PR DESCRIPTION
nova_instance i18n key was accidentally removed in
660e0aebd1bf6a46ece344d9fd7cd0692f5b5b4b, add it back.