### PR TITLE
Only enable resize tests if more than one node is there

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -291,6 +291,9 @@ if backend_names.length > 1
   cinder_backend2_name = backend_names[1]
 end
 
+compute_nodes = search(:node, "roles:nova-multi-compute-kvm") || []
+use_resize = compute_nodes.length > 1
+
 # FIXME: should avoid search with no environment in query
 horizons = search(:node, "roles:nova_dashboard-server") || []
 if horizons.empty?
@@ -337,6 +340,7 @@ template "#{tempest_conf}" do
     :flavor_ref => flavor_ref,
     :alt_flavor_ref => alt_flavor_ref,
     :nova_api_v3 => nova[:nova][:enable_v3_api],
+    :use_resize => use_resize,
     # dashboard settings
     :horizon_host => horizon_host,
     :horizon_protocol => horizon_protocol,

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -406,7 +406,7 @@ api_v3_extensions = all
 #rdp_console = false
 
 # Does the test environment support resizing? (boolean value)
-resize = true
+resize = <%= @use_resize %>
 
 # Enable Spice console. This configuration value should be same as
 # [nova.spice]->enabled in nova.conf (boolean value)


### PR DESCRIPTION
If there is only one compute node, resize will fail by default
as allow_resize_to_same_host is not set.