### PR TITLE
make tempest work in an SSL cloud

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -133,7 +133,7 @@ docker_image_id_file = node[:tempest][:tempest_path] + '/docker_machine.id'
 heat_machine_id_file = node[:tempest][:tempest_path] + '/heat_machine.id'
 
 glance_node = search(:node, "roles:glance-server").first
-insecure = (keystone_settings["insecure"] || glance_node[:glance][:ssl][:insecure]) ? "--insecure" : ""
+insecure = "--insecure"
 
 cirros_version = File.basename(node[:tempest][:tempest_test_image]).gsub(/^cirros-/, "").gsub(/-.*/, "")
 

--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -53,7 +53,7 @@ keystone_register "create tenant #{tempest_comp_tenant} for tempest" do
   action :add_tenant
 end.run_action(:add_tenant)
 
-keystone = "keystone --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url #{keystone_settings["internal_auth_url"]}"
+keystone = "keystone --insecure --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url #{keystone_settings["internal_auth_url"]}"
 %x{#{keystone} endpoint-get --service orchestration &> /dev/null}
 use_heat = $?.success?
 
@@ -244,6 +244,7 @@ EOH
     'OS_USERNAME' => tempest_adm_user,
     'OS_PASSWORD' => tempest_adm_pass,
     'OS_TENANT_NAME' => tempest_comp_tenant,
+    'NOVACLIENT_INSECURE' => 'true',
     'OS_AUTH_URL' => keystone_settings["internal_auth_url"]
   })
 end
@@ -269,7 +270,7 @@ unless neutrons[0].nil?
   end
 end
 
-public_network_id = `neutron --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url #{keystone_settings["internal_auth_url"]} net-list -f csv -c id -- --name floating | tail -n 1 | cut -d'"' -f2`.strip
+public_network_id = `neutron --insecure --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url #{keystone_settings["internal_auth_url"]} net-list -f csv -c id -- --name floating | tail -n 1 | cut -d'"' -f2`.strip
 raise("Cannot fetch ID of floating network") if public_network_id.empty?
 
 # FIXME: the command above should be good enough, but radosgw is broken with

--- a/chef/cookbooks/tempest/templates/default/tempest_cleanup.sh.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest_cleanup.sh.erb
@@ -4,6 +4,16 @@ export OS_AUTH_URL=<%= @keystone_settings['internal_auth_url'] %>
 export OS_AUTH_STRATEGY=keystone
 export OS_REGION_NAME='<%= @keystone_settings['endpoint_region'] %>'
 
+<% if keystone_settings['insecure'] -%>
+function keystone()
+{
+    command keystone --insecure "$@"
+}
+<% end -%>
+
+export NEUTRONCLIENT_INSECURE=true
+export NOVACLIENT_INSECURE=true
+
 ### clean up in admin tenant
 (
 export OS_USERNAME=<%= @keystone_settings['admin_user'] %>


### PR DESCRIPTION
since tempest is not used in production,
and accessing services over the admin network,
we do not need to verify certificates

This is needed for SSL+tempest tests in mkcloud