### PR TITLE
Allocate a public IP address for tempest node

### DIFF
--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -94,6 +94,12 @@ class TempestService < ServiceObject
 
     role.save
 
+    # Allocate a public IP, tempest needs it
+    net_svc = NetworkService.new @logger
+    NodeObject.find("roles:tempest").each do |n|
+      net_svc.allocate_ip "default", "public", "host", n
+    end
+
     @logger.debug("Tempest apply_role_pre_chef_call: leaving")
   end
 


### PR DESCRIPTION
tempest requires the node to have a public IP address.
Make sure that one is allocated.