### PR TITLE
Fix public IP allocation

### DIFF
--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -96,7 +96,7 @@ class TempestService < ServiceObject
 
     # Allocate a public IP, tempest needs it
     net_svc = NetworkService.new @logger
-    NodeObject.find("roles:tempest").each do |n|
+    all_nodes.each do |n|
       net_svc.allocate_ip "default", "public", "host", n
     end
 


### PR DESCRIPTION
NetworkService.allocate_ip takes node names as the input, not NodeObjects (as
returned by NodeObject.find_node_by_name). 'all_nodes' as passed into
apply_role_pre_chef_call() already has what we need here.