### PR TITLE
Revert "Adjustments for using the keystone v3 API"

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -53,13 +53,8 @@ keystone_register "create tenant #{tempest_comp_tenant} for tempest" do
   action :add_tenant
 end.run_action(:add_tenant)
 
-v2_auth_url = KeystoneHelper.versioned_service_URL(
-    keystone_settings["protocol"], keystone_settings["internal_url_host"],
-    keystone_settings["service_port"], "2.0")
-keystonev2 = "keystone --insecure --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url #{v2_auth_url}"
 keystone = "keystone --insecure --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url #{keystone_settings["internal_auth_url"]}"
-
-%x{#{keystonev2} endpoint-get --service orchestration &> /dev/null}
+%x{#{keystone} endpoint-get --service orchestration &> /dev/null}
 use_heat = $?.success?
 
 users = [
@@ -150,8 +145,6 @@ export OS_USERNAME=${OS_USERNAME:-admin}
 export OS_TENANT_NAME=${OS_TENANT_NAME:-admin}
 export OS_PASSWORD=${OS_PASSWORD:-admin}
 export OS_AUTH_URL
-export OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-Default}
-export OS_PROJECT_DOMAIN_NAME=${OS_PROJECT_DOMAIN_NAME:-Default}
 
 TEMP=$(mktemp -d)
 IMG_DIR=$TEMP/image
@@ -210,9 +203,7 @@ EOH
     'OS_USERNAME' => tempest_adm_user,
     'OS_PASSWORD' => tempest_adm_pass,
     'OS_TENANT_NAME' => tempest_comp_tenant,
-    'OS_AUTH_URL' => keystone_settings["internal_auth_url"],
-    'OS_USER_DOMAIN_NAME' => "Default",
-    'OS_PROJECT_DOMAIN_NAME' => "Default"
+    'OS_AUTH_URL' => keystone_settings["internal_auth_url"]
   })
   not_if { File.exists?(machine_id_file) }
 end
@@ -222,8 +213,6 @@ bash "upload tempest heat-cfntools image" do
 OS_USERNAME=${OS_USERNAME:-admin}
 OS_TENANT_NAME=${OS_TENANT_NAME:-admin}
 OS_PASSWORD=${OS_PASSWORD:-admin}
-OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-Default}
-OS_PROJECT_DOMAIN_NAME=${OS_PROJECT_DOMAIN_NAME:-Default}
 
 id=$(glance #{insecure} image-show ${IMAGE_NAME} | awk '/id/ { print $4}')
 [ -n "$id" ] && echo $id > #{heat_machine_id_file}
@@ -235,9 +224,7 @@ EOF
     'OS_USERNAME' => tempest_adm_user,
     'OS_PASSWORD' => tempest_adm_pass,
     'OS_TENANT_NAME' => tempest_comp_tenant,
-    'OS_AUTH_URL' => keystone_settings["internal_auth_url"],
-    'OS_USER_DOMAIN_NAME' => "Default",
-    'OS_PROJECT_DOMAIN_NAME' => "Default"
+    'OS_AUTH_URL' => keystone_settings["internal_auth_url"]
   })
 
   not_if { node[:tempest][:heat_test_image_name].nil? or File.exists?(heat_machine_id_file) }
@@ -258,19 +245,17 @@ EOH
     'OS_PASSWORD' => tempest_adm_pass,
     'OS_TENANT_NAME' => tempest_comp_tenant,
     'NOVACLIENT_INSECURE' => 'true',
-    'OS_AUTH_URL' => keystone_settings["internal_auth_url"],
-    'OS_USER_DOMAIN_NAME' => "Default",
-    'OS_PROJECT_DOMAIN_NAME' => "Default"
+    'OS_AUTH_URL' => keystone_settings["internal_auth_url"]
   })
 end
 
-ec2_access = `#{keystonev2} ec2-credentials-list | grep -v -- '\\-\\{5\\}' | tail -n 1 | tr -d '|' | awk '{print $2}'`.strip
-ec2_secret = `#{keystonev2} ec2-credentials-list | grep -v -- '\\-\\{5\\}' | tail -n 1 | tr -d '|' | awk '{print $3}'`.strip
+ec2_access = `#{keystone} ec2-credentials-list | grep -v -- '\\-\\{5\\}' | tail -n 1 | tr -d '|' | awk '{print $2}'`.strip
+ec2_secret = `#{keystone} ec2-credentials-list | grep -v -- '\\-\\{5\\}' | tail -n 1 | tr -d '|' | awk '{print $3}'`.strip
 raise("Cannot fetch EC2 credentials ") if ec2_access.empty? || ec2_secret.empty?
 
-%x{#{keystonev2} endpoint-get --service metering &> /dev/null}
+%x{#{keystone} endpoint-get --service metering &> /dev/null}
 use_ceilometer = $?.success?
-%x{#{keystonev2} endpoint-get --service database &> /dev/null}
+%x{#{keystone} endpoint-get --service database &> /dev/null}
 use_trove = $?.success?
 
 # FIXME: should avoid search with no environment in query
@@ -285,7 +270,7 @@ unless neutrons[0].nil?
   end
 end
 
-public_network_id = `neutron --insecure --os-user-domain-name Default --os-project-domain-name Default --os-username #{tempest_comp_user} --os-password #{tempest_comp_pass} --os-tenant-name #{tempest_comp_tenant} --os-auth-url #{keystone_settings["internal_auth_url"]} net-list -f csv -c id -- --name floating | tail -n 1 | cut -d'"' -f2`.strip
+public_network_id = `neutron --insecure --os_username #{tempest_comp_user} --os_password #{tempest_comp_pass} --os_tenant_name #{tempest_comp_tenant} --os_auth_url #{keystone_settings["internal_auth_url"]} net-list -f csv -c id -- --name floating | tail -n 1 | cut -d'"' -f2`.strip
 raise("Cannot fetch ID of floating network") if public_network_id.empty?
 
 # FIXME: the command above should be good enough, but radosgw is broken with

--- a/chef/cookbooks/tempest/templates/default/tempest.conf.erb
+++ b/chef/cookbooks/tempest/templates/default/tempest.conf.erb
@@ -542,7 +542,7 @@ endpoint_type = internalURL
 
 # Admin domain name for authentication (Keystone V3).The same domain
 # applies to user and project (string value)
-admin_domain_name = Default
+#admin_domain_name = <None>
 
 # API key to use when authenticating as admin. (string value)
 admin_password = <%= @keystone_settings['admin_password'] %>
@@ -560,7 +560,7 @@ admin_username = <%= @keystone_settings['admin_user'] %>
 
 # Alternate domain name for authentication (Keystone V3).The same
 # domain applies to user and project (string value)
-alt_domain_name = Default
+#alt_domain_name = <None>
 
 # API key to use when authenticating as alternate user. (string value)
 alt_password = <%=@alt_comp_pass %>
@@ -575,7 +575,7 @@ alt_username = <%=@alt_comp_user %>
 
 # Identity API version to be used for authentication for API tests.
 # (string value)
-auth_version = <%= "v#{@keystone_settings['api_version']}" %>
+#auth_version = v2
 
 # Specify a CA bundle file to use in verifying a TLS (https) server
 # certificate. (string value)
@@ -589,7 +589,7 @@ disable_ssl_certificate_validation = <%= @ssl_insecure ? 'true' : 'false' %>
 
 # Domain name for authentication (Keystone V3).The same domain applies
 # to user and project (string value)
-domain_name = Default
+#domain_name = <None>
 
 # The endpoint type to use for the identity service. (string value)
 endpoint_type = internalURL


### PR DESCRIPTION
Reverts crowbar/barclamp-tempest#149

glance apparently stumbles over $OS_USER_DOMAIN_NAME when using the v2.0 api and only aborts with "token required"