### PR TITLE
Allocate an IP from floating range

### DIFF
--- a/crowbar_framework/app/models/tempest_service.rb
+++ b/crowbar_framework/app/models/tempest_service.rb
@@ -97,7 +97,7 @@ class TempestService < ServiceObject
     # Allocate a public IP, tempest needs it
     net_svc = NetworkService.new @logger
     all_nodes.each do |n|
-      net_svc.allocate_ip "default", "public", "host", n
+      net_svc.allocate_ip "default", "floating", "host", n
     end
 
     @logger.debug("Tempest apply_role_pre_chef_call: leaving")


### PR DESCRIPTION
public range was wrong from the beginning, and it matters
if public and floating are not the same
