### PR TITLE
do not fail when docker image is not present

### DIFF
--- a/chef/cookbooks/tempest/recipes/config.rb
+++ b/chef/cookbooks/tempest/recipes/config.rb
@@ -358,6 +358,7 @@ DOCKER_IMAGE_ID=$(glance #{insecure} image-list \
     --page-size 1 \
     2> /dev/null | tail -n 2 | head -n 1 | awk '{ print $2 }')
 [ -n "$DOCKER_IMAGE_ID" ] && echo "$DOCKER_IMAGE_ID" > #{docker_image_id_file}
+true
 EOH
     environment ({
       'OS_USERNAME' => tempest_adm_user,


### PR DESCRIPTION
do not fail when docker image is not present
(it might be added later)

Should fix failure in tempest deployment when docker is used